### PR TITLE
Support for private windows (illegal cookieStoreId)

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -183,6 +183,11 @@ export async function openURL(
         url: getMangledURL(url),
         cookieStoreId: DEFAULT_COOKIE_STORE_ID,
       });
+    } else if (e.message === "Illegal to set non-private cookieStoreId in a private window") {
+      return await browser.tabs.create({
+        url: getMangledURL(url),
+        cookieStoreId: PRIVATE_COOKIE_STORE_ID,
+      });
     } else {
       throw e;
     }


### PR DESCRIPTION
See #28 
To summarize, I can't open tab in private windows because it wants to open it with the default firefox container ( "firefox-default" ), while in private window, it should use "firefox-private".